### PR TITLE
KAN-4-create-gitignore-for-backend

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,2 @@
+instance/calendar.db
+__pycache__


### PR DESCRIPTION
Add .gitignore to exclude __pycache__ and database files from being committed to Git.