### PR TITLE
KAN-9-add-a-relationship-table

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -1,8 +1,14 @@
 import datetime
 from config import db
 from typing import Optional, List
-from sqlalchemy import ARRAY, String, Integer, DateTime
+from sqlalchemy import Column, String, Integer, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
+
+task_tags = db.Table (  # Association table for tasks to tags
+    'task_tags',
+    Column('task_id', Integer, ForeignKey('task.id')),
+    Column('tag_id', Integer, ForeignKey('tag.id'))
+)
 
 class Task(db.Model):
     __tablename__ = "task"
@@ -11,7 +17,6 @@ class Task(db.Model):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[Optional[str]] = mapped_column(String(4096))
     type: Mapped[str] = mapped_column(String(20), nullable=False)  # indicate whether assignment or test type
-    tags: Mapped[List[str]] = mapped_column(ARRAY(String))  # subtypes enable finer task categories e.g, midterm, survey
     grade_weight: Mapped[int] = mapped_column(Integer)  # weight of task e.g, 5%
     grade_achieved: Mapped[int] = mapped_column(Integer)
     course_code: Mapped[str] = mapped_column(String(50))
@@ -19,8 +24,9 @@ class Task(db.Model):
     time_start: Mapped[datetime.datetime] = mapped_column(DateTime)
     time_end: Mapped[datetime.datetime] = mapped_column(DateTime)  # must end after start date
     subtask_ids: Mapped[List[int]] = mapped_column(ARRAY(Integer))  # one task can link to multiple subtasks
+    tags = db.relationship('Tag', secondary=task_tags, back_populates='tasks')  # subtypes enable finer task categories e.g, midterm, survey
 
-class SubTask(db.Model):
+class Subtask(db.Model):
     __tablename__ = "subtask"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
@@ -30,3 +36,10 @@ class SubTask(db.Model):
     status: Mapped[str] = mapped_column(String(20), nullable=False)  # status is independent of its parents
     time_start: Mapped[datetime.datetime] = mapped_column(DateTime)
     time_end: Mapped[datetime.datetime] = mapped_column(DateTime)
+
+class Tag(db.Model):
+    __tablename__ = "tag"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    tag_value: Mapped[str] = mapped_column(String(50), nullable=False)
+    tasks = db.relationship('Task', secondary=task_tags, back_populated='tags')

--- a/backend/models.py
+++ b/backend/models.py
@@ -23,7 +23,6 @@ class Task(db.Model):
     status: Mapped[str] = mapped_column(String(20), nullable=False)  # status of task e.g, todo, doing, done, blocked
     time_start: Mapped[datetime.datetime] = mapped_column(DateTime)
     time_end: Mapped[datetime.datetime] = mapped_column(DateTime)  # must end after start date
-    subtask_ids: Mapped[List[int]] = mapped_column(ARRAY(Integer))  # one task can link to multiple subtasks
     tags = db.relationship('Tag', secondary=task_tags, back_populates='tasks')  # subtypes enable finer task categories e.g, midterm, survey
 
 class Subtask(db.Model):
@@ -36,6 +35,7 @@ class Subtask(db.Model):
     status: Mapped[str] = mapped_column(String(20), nullable=False)  # status is independent of its parents
     time_start: Mapped[datetime.datetime] = mapped_column(DateTime)
     time_end: Mapped[datetime.datetime] = mapped_column(DateTime)
+    parent_task_id: Mapped[int]  # one task can link to multiple subtasks
 
 class Tag(db.Model):
     __tablename__ = "tag"

--- a/backend/models.py
+++ b/backend/models.py
@@ -16,8 +16,8 @@ class Task(db.Model):
     grade_achieved: Mapped[int] = mapped_column(Integer)
     course_code: Mapped[str] = mapped_column(String(50))
     status: Mapped[str] = mapped_column(String(20), nullable=False)  # status of task e.g, todo, doing, done, blocked
-    time_start: Optional[datetime.datetime] = mapped_column(DateTime)
-    time_end: Optional[datetime.datetime] = mapped_column(DateTime)  # must end after start date
+    time_start: Mapped[datetime.datetime] = mapped_column(DateTime)
+    time_end: Mapped[datetime.datetime] = mapped_column(DateTime)  # must end after start date
     subtask_ids: Mapped[List[int]] = mapped_column(ARRAY(Integer))  # one task can link to multiple subtasks
 
 class SubTask(db.Model):
@@ -28,5 +28,5 @@ class SubTask(db.Model):
     description: Mapped[Optional[str]] = mapped_column(String(4096))
     # type must be identical to type of its task parent
     status: Mapped[str] = mapped_column(String(20), nullable=False)  # status is independent of its parents
-    time_start: Optional[datetime.datetime] = mapped_column(DateTime)
-    time_end: Optional[datetime.datetime] = mapped_column(DateTime)
+    time_start: Mapped[datetime.datetime] = mapped_column(DateTime)
+    time_end: Mapped[datetime.datetime] = mapped_column(DateTime)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,7 @@
 import datetime
 from config import db
 from typing import Optional, List
-from sqlalchemy import Column, String, Integer, DateTime, ForeignKey
+from sqlalchemy import Column, String, Integer, Float, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column
 
 task_tags = db.Table (  # Association table for tasks to tags
@@ -15,14 +15,14 @@ class Task(db.Model):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    description: Mapped[Optional[str]] = mapped_column(String(4096))
+    description: Mapped[str] = mapped_column(String(4096), nullable=True)
     type: Mapped[str] = mapped_column(String(20), nullable=False)  # indicate whether assignment or test type
-    grade_weight: Mapped[int] = mapped_column(Integer)  # weight of task e.g, 5%
-    grade_achieved: Mapped[int] = mapped_column(Integer)
-    course_code: Mapped[str] = mapped_column(String(50))
-    status: Mapped[str] = mapped_column(String(20), nullable=False)  # status of task e.g, todo, doing, done, blocked
-    time_start: Mapped[datetime.datetime] = mapped_column(DateTime)
-    time_end: Mapped[datetime.datetime] = mapped_column(DateTime)  # must end after start date
+    grade_weight = mapped_column(Float, nullable=True)  # weight of task e.g, 5%
+    grade_achieved: Mapped[float] = mapped_column(Float, nullable=True)
+    course_code: Mapped[str] = mapped_column(String(50), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), default='TODO')  # status of task e.g, todo, doing, done, blocked
+    time_start: Mapped[str] = mapped_column(String(50), default=str(datetime.datetime.now()))
+    time_end: Mapped[str] = mapped_column(String(50), nullable=True)  # must end after start date
     tags = db.relationship('Tag', secondary=task_tags, back_populates='tasks')  # subtypes enable finer task categories e.g, midterm, survey
 
 class Subtask(db.Model):
@@ -30,16 +30,16 @@ class Subtask(db.Model):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String(255), nullable=False)
-    description: Mapped[Optional[str]] = mapped_column(String(4096))
+    description: Mapped[Optional[str]] = mapped_column(String(4096), nullable=True)
     # type must be identical to type of its task parent
-    status: Mapped[str] = mapped_column(String(20), nullable=False)  # status is independent of its parents
-    time_start: Mapped[datetime.datetime] = mapped_column(DateTime)
-    time_end: Mapped[datetime.datetime] = mapped_column(DateTime)
-    parent_task_id: Mapped[int]  # one task can link to multiple subtasks
+    status: Mapped[str] = mapped_column(String(20), default='TODO')  # status is independent of its parents
+    time_start: Mapped[str] = mapped_column(String(50), default=str(datetime.datetime.now()))
+    time_end: Mapped[str] = mapped_column(String(50), nullable=True)
+    parent_task_id: Mapped[int] = mapped_column(Integer, nullable=True)  # one task can link to multiple subtasks
 
 class Tag(db.Model):
     __tablename__ = "tag"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     tag_value: Mapped[str] = mapped_column(String(50), nullable=False)
-    tasks = db.relationship('Task', secondary=task_tags, back_populated='tags')
+    tasks = db.relationship('Task', secondary=task_tags, back_populates='tags')


### PR DESCRIPTION
1. Replacing arrays with association table: Previously, each task held a list of tags, which was problematic as arrays are not supported in non-PostgreSQL databases. To resolve this, I've replaced the arrays with an association table to support the many-to-many relationship between tags and tasks. I also created a new table: Tags.

2. Redesigned relationship between subtasks and parent Tasks: I removed the Subtask array in the parent Tasks table, as Array are not supported. In the Subtask table, I've added the tasks attribute with parent_task_id, just a better designed database schema.

3. BUGFIX: Optional fields were not working as optional fields. I added specification for all fields pertaining to null-ability. 

4. Quality of life: Converted grade_weight and grade_achieve fields to Float type, allowing for those times when an assignment is worth 33.33%